### PR TITLE
feat(angular2): Upgrade to Angular 2 RC6 (uses latest TypeScript)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *~
+
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 
 node_modules
+*.js
+*.js.map

--- a/package.json
+++ b/package.json
@@ -15,6 +15,12 @@
     "type": "git",
     "url": "https://github.com/izupet/angular2-counto.git"
   },
+  "dependencies": {
+    "@angular/core": "^2.0.0-rc.6",
+    "core-js": "^2.4.1",
+    "rxjs": "^5.0.0-beta.11",
+    "zone.js": "^0.6.17"
+  },
   "keywords": [
     "angular2",
     "count",
@@ -25,5 +31,9 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/izupet/angular2-counto/issues"
+  },
+  "devDependencies": {
+    "@types/core-js": "^0.9.32",
+    "typescript": "^2.0.0"
   }
 }

--- a/src/counto.directive.ts
+++ b/src/counto.directive.ts
@@ -1,8 +1,7 @@
-import {Directive, Output, EventEmitter} from 'angular2/core';
+import {Directive, Input, Output, EventEmitter} from '@angular/core';
 
 @Directive({
-    selector: 'counto',
-    properties: ['duration: duration', 'countFrom: countFrom', 'countTo: countTo', 'step: step']
+    selector: 'counto'
 })
 
 export class Counto {
@@ -14,21 +13,25 @@ export class Counto {
     private _countFrom: number;
     private _step: number;
 
+    @Input()
     set duration(duration) {
         this._duration = parseFloat(duration);
         this.run();
     }
 
+    @Input()
     set countTo(countTo) {
         this._countTo = parseFloat(countTo);
         this.run();
     }
 
+    @Input()
     set countFrom(countFrom) {
         this._countFrom = parseFloat(countFrom);
         this.run();
     }
 
+    @Input()
     set step(step) {
         this._step = parseFloat(step);
         this.run();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
   ],
   "files": [
     "./angular2-counto.ts",
-    "./src/counto-directiove.ts"
+    "./src/counto.directive.ts"
   ]
 }


### PR DESCRIPTION
This PR adds the following:
- Changing syntax and imports to work with Angular 2 recent RCs
- Adding NPM depdencies on Angular 2 RC6
- Setting a working TypeScript build from `npm run tsc` on any PC
